### PR TITLE
Fixing mavenrepo definition

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -9,6 +9,7 @@ grails.project.dependency.resolution = {
         grailsCentral()
         mavenLocal()
         mavenCentral()
+        mavenRepo "http://repo.grails.org/grails/plugins/"
     }
 
     dependencies {


### PR DESCRIPTION
While looking into upgrading a Grails 2.2.1 project that depends on this plugin, I happened to clone it. When I ran, it couldn't resolve dependencies. It was due to maven repo that got changed and older versions of Grails were not updated accordingly.